### PR TITLE
Provide locked requirements for backup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 .DS_Store
+
+Pipfile*

--- a/confluence/backup/requirements.txt
+++ b/confluence/backup/requirements.txt
@@ -1,1 +1,7 @@
+argcomplete==1.10.0
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 requests==2.24.0
+six==1.12.0
+urllib3==1.25.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'


### PR DESCRIPTION
How to get (all) locked requirements? First, download (transitive) dependencies
on a machine with access to pypi.org, and then store all values in the
requirements.txt e.g. using pipenv like this:

```
pipenv install -r requirements.txt
pipenv lock -r > requirements.txt
```

Then, remove the index URL from requirements.txt again!